### PR TITLE
WIP - Changes to support comparing histograms

### DIFF
--- a/Project 3/block_quantize.py
+++ b/Project 3/block_quantize.py
@@ -13,6 +13,12 @@ import matplotlib.pyplot as plt
 import utility as util
 from os import listdir, path
 
+def replace_value(block,value,new_value):
+    for i in range(len(block)):
+        for j in range(len(block[0])):
+            if block[i][j] == value:
+                block[i][j] = new_value
+
 def quantize_block(block, bins, frame_num, block_x, block_y):
     '''
     Quantizes a block using the number of bins
@@ -30,19 +36,22 @@ def quantize_block(block, bins, frame_num, block_x, block_y):
     for val in np.nditer(block):
         if bin_size == 0:
             quantized_value = min_value
+            replace_value(block, val, quantized_value)
         else:
             quanta = math.floor((val - min_value) / bin_size) + 0.5
             quantized_value = min_value + quanta * bin_size
+            replace_value(block, val, quantized_value)
 
         if quantized_value >= max_value:
             quantized_value = min_value + (bins - 0.5)*bin_size
+            replace_value(block, val, quantized_value)
 
         quantized_value = round(quantized_value, 7)
         frame_occurances[quantized_value] += 1
 
     result = list()
 
-    block_hist = cv2.calcHist([block.astype(np.uint8)],[0],None,[bins],[0,256]) #We could do our local min/max here but lets keep the range (0,256) the same for comparison reasons
+    block_hist = cv2.calcHist([block.astype(np.uint8)],[0],None,[bins],[min_value,max_value]) #We could do our local min/max here but lets keep the range (0,256) the same for comparison reasons
 
     for key in frame_occurances:
         result.append({

--- a/Project 3/block_quantize.py
+++ b/Project 3/block_quantize.py
@@ -72,7 +72,6 @@ def quantize(frame_data, n):
 
     result = list()
     frame_block_dict = {}   #stores block dictionary which contains histogram data for blocks
-    block_hist_dict = {}    #stores histogram data for blocks of a frame
     frame_num = 0
 
     #for each entry in frame_data
@@ -80,6 +79,7 @@ def quantize(frame_data, n):
         frame_num += 1
         print 'Processing regions of frame: ' + str(frame_num)
         for block_x in range(0, len(frame), 8):
+            block_hist_dict = {}    #stores histogram data for blocks of a frame
             for block_y in range(0, len(frame[block_x]), 8):
                 block = frame[block_x:block_x+8, block_y:block_y+8]
                 block_dict,block_hist = quantize_block(block, n, frame_num, block_x, block_y)

--- a/Project 3/block_quantize.py
+++ b/Project 3/block_quantize.py
@@ -51,6 +51,9 @@ def quantize_block(block, bins, frame_num, block_x, block_y):
 
     result = list()
 
+    if min_value == max_value:
+        max_value += 1
+
     block_hist = cv2.calcHist([block.astype(np.uint8)],[0],None,[bins],[min_value,max_value]) #We could do our local min/max here but lets keep the range (0,256) the same for comparison reasons
 
     for key in frame_occurances:

--- a/Project 3/block_quantize.py
+++ b/Project 3/block_quantize.py
@@ -49,7 +49,7 @@ def quantize_block(block, bins, frame_num, block_x, block_y):
             'frame_num': frame_num,
             'block_coords': (block_x, block_y),
             'key': key,
-            'val': frame_occurances[key],
+            'val': frame_occurances[key]
         })
 
     return result, block_hist #only 1 histogram per block, dont save to dict for each value in block, but return for the whole block and construct dict to access for compare

--- a/Project 3/diff_quantize.py
+++ b/Project 3/diff_quantize.py
@@ -10,7 +10,7 @@ def diff_quantize(frame_data, n):
     diff_frame_data = np.diff(frame_data, axis=0)
     # Quantize the blocks of the video
     quantized_values,frame_block_dict = quantize(diff_frame_data, n)
-    return quantized_values
+    return quantized_values, frame_block_dict
 
 
 if __name__ == '__main__':

--- a/Project 3/diff_quantize.py
+++ b/Project 3/diff_quantize.py
@@ -9,7 +9,7 @@ from block_quantize import quantize, display_histogram
 def diff_quantize(frame_data, n):
     diff_frame_data = np.diff(frame_data, axis=0)
     # Quantize the blocks of the video
-    quantized_values = quantize(diff_frame_data, n)
+    quantized_values,frame_block_dict = quantize(diff_frame_data, n)
     return quantized_values
 
 

--- a/Project 3/match_frame.py
+++ b/Project 3/match_frame.py
@@ -72,6 +72,47 @@ def show_ten_closest(frame_data, feature_summary, frame_num, description):
     cv2.destroyAllWindows()
     return
 
+def show_ten_quantized_closest(frame_data,frame_block_dict,target_frame_number, bins, description ):
+    target_frame = frame_data[target_frame_number-1]  #we need to create block histograms for this frame
+    target_frame_block_hist_dict = {}
+    top_ten_frames = [(0,100000000)] * 10 #sufficently large values that will be replace later
+
+    for block_x in range(0, len(target_frame), 8):  #create histogram for the given frame
+            for block_y in range(0, len(target_frame[block_x]), 8):
+                target_frame_block = target_frame[block_x:block_x+8, block_y:block_y+8]
+                target_frame_block_hist = cv2.calcHist([target_frame_block.astype(np.uint8)],[0],None,[bins],[0,256])
+                target_frame_block_hist_dict[block_x,block_y] = target_frame_block_hist
+
+    print("Comparing frames...")
+    for keyA in frame_block_dict:
+        if keyA == target_frame_number:  #dont compare the frame against itself
+            continue
+        else:
+            frame_score = 0
+            for keyB in frame_block_dict[keyA]:
+                block_hist = frame_block_dict[keyA][keyB[0],keyB[1]]
+                frame_score += cv2.compareHist(target_frame_block_hist_dict[keyB[0],keyB[1]],block_hist, 1)
+
+        largest_diff = 0
+        replace_index = -1
+        for i in range (0,10):
+            diff = top_ten_frames[i][1] - frame_score
+            if largest_diff < diff:
+                largest_diff = diff
+                replace_index = i
+        if replace_index >= 0:
+            top_ten_frames[replace_index] = keyA,largest_diff
+
+    top_ten_frames = list((x[0] for x in top_ten_frames))    #just need to the frame number, not the diff so we strip that out
+    for i in range(0,10):
+        # For each of those frame numbers, display the image in a window with the number
+        index = top_ten_frames[i]
+        rgb_target = cv2.cvtColor(frame_data[index].astype(np.uint8), cv2.COLOR_GRAY2BGR)
+        cv2.imshow(description + ' ' + str(i), rgb_target)
+        cv2.waitKey(0)
+
+    cv2.destroyAllWindows()
+
 
 if __name__ == '__main__':
     if len(sys.argv) == 1:
@@ -97,12 +138,13 @@ if __name__ == '__main__':
 
     target_frame_data = frame_data[f-1]
     rgb_target = cv2.cvtColor(target_frame_data.astype(np.uint8), cv2.COLOR_GRAY2BGR)
-    cv2.imshow('Original frame', rgb_target)
-    print 'Displaying Original frame - press any key to continue :)'
-    cv2.waitKey(0)
+    #cv2.imshow('Original frame', rgb_target)
+    #print 'Displaying Original frame - press any key to continue :)'
+    #cv2.waitKey(0)
 
-    block_quantized = quantize(frame_data, n)
-    show_ten_closest(frame_data, block_quantized, f, 'Quantization')
+    block_quantized, frame_block_dict = quantize(frame_data, n)
+    block_quantized = None #free memory for this, returned from argument but not applicable here
+    show_ten_quantized_closest(frame_data, frame_block_dict, f, n, 'Quantization')
 
     block_dct = FindDiscreteCosineTransform(frame_data, n)
     show_ten_closest(frame_data, block_dct, f, 'DCT')

--- a/Project 3/match_frame.py
+++ b/Project 3/match_frame.py
@@ -91,7 +91,7 @@ def show_ten_quantized_closest(frame_data,frame_block_dict,target_frame_number, 
             frame_score = float(0)
             for keyB in frame_block_dict[keyA]:
                 block_hist = frame_block_dict[keyA][keyB[0],keyB[1]]
-                frame_score += cv2.compareHist(target_frame_block_hist_dict[keyB[0],keyB[1]],block_hist, 2)
+                frame_score += cv2.compareHist(target_frame_block_hist_dict[keyB[0],keyB[1]],block_hist, 1) #Chi-Square compare method, smaller number = higher similarity
 
         top_ten_frames.append((keyA, frame_score))
 

--- a/Project 3/match_frame.py
+++ b/Project 3/match_frame.py
@@ -91,12 +91,11 @@ def show_ten_quantized_closest(frame_data,frame_block_dict,target_frame_number, 
             frame_score = float(0)
             for keyB in frame_block_dict[keyA]:
                 block_hist = frame_block_dict[keyA][keyB[0],keyB[1]]
-                frame_score += cv2.compareHist(target_frame_block_hist_dict[keyB[0],keyB[1]],block_hist, 1) #Chi-Square compare method, smaller number = higher similarity
+                frame_score += cv2.compareHist(target_frame_block_hist_dict[keyB[0],keyB[1]],block_hist, 0) #Correlation compare
 
         top_ten_frames.append((keyA, frame_score))
 
     top_ten_frames.sort(key=lambda tup: tup[1])  # sorts in place
-    top_ten_frames = top_ten_frames[:10]
 
     top_ten_frames = list((x[0] for x in top_ten_frames))    #just need to the frame number, not the diff so we strip that out
     for i in range(0,10):

--- a/Project 3/match_frame.py
+++ b/Project 3/match_frame.py
@@ -75,7 +75,7 @@ def show_ten_closest(frame_data, feature_summary, frame_num, description):
 def show_ten_quantized_closest(frame_data,frame_block_dict,target_frame_number, bins, description ):
     target_frame = frame_data[target_frame_number-1]  #we need to create block histograms for this frame
     target_frame_block_hist_dict = {}
-    top_ten_frames = [(0,100000000)] * 10 #sufficently large values that will be replace later
+    top_ten_frames = list()
 
     for block_x in range(0, len(target_frame), 8):  #create histogram for the given frame
             for block_y in range(0, len(target_frame[block_x]), 8):
@@ -88,20 +88,15 @@ def show_ten_quantized_closest(frame_data,frame_block_dict,target_frame_number, 
         if keyA == target_frame_number:  #dont compare the frame against itself
             continue
         else:
-            frame_score = 0
+            frame_score = float(0)
             for keyB in frame_block_dict[keyA]:
                 block_hist = frame_block_dict[keyA][keyB[0],keyB[1]]
-                frame_score += cv2.compareHist(target_frame_block_hist_dict[keyB[0],keyB[1]],block_hist, 1)
+                frame_score += cv2.compareHist(target_frame_block_hist_dict[keyB[0],keyB[1]],block_hist, 2)
 
-        largest_diff = 0
-        replace_index = -1
-        for i in range (0,10):
-            diff = top_ten_frames[i][1] - frame_score
-            if largest_diff < diff:
-                largest_diff = diff
-                replace_index = i
-        if replace_index >= 0:
-            top_ten_frames[replace_index] = keyA,largest_diff
+        top_ten_frames.append((keyA, frame_score))
+
+    top_ten_frames.sort(key=lambda tup: tup[1])  # sorts in place
+    top_ten_frames = top_ten_frames[:10]
 
     top_ten_frames = list((x[0] for x in top_ten_frames))    #just need to the frame number, not the diff so we strip that out
     for i in range(0,10):
@@ -138,9 +133,9 @@ if __name__ == '__main__':
 
     target_frame_data = frame_data[f-1]
     rgb_target = cv2.cvtColor(target_frame_data.astype(np.uint8), cv2.COLOR_GRAY2BGR)
-    #cv2.imshow('Original frame', rgb_target)
-    #print 'Displaying Original frame - press any key to continue :)'
-    #cv2.waitKey(0)
+    cv2.imshow('Original frame', rgb_target)
+    print 'Displaying Original frame - press any key to continue :)'
+    cv2.waitKey(0)
 
     block_quantized, frame_block_dict = quantize(frame_data, n)
     block_quantized = None #free memory for this, returned from argument but not applicable here

--- a/Project 3/match_frame.py
+++ b/Project 3/match_frame.py
@@ -146,8 +146,8 @@ if __name__ == '__main__':
     block_dwt = video_blockdwt(frame_data, n)
     show_ten_closest(frame_data, block_dwt, f, 'Block-level DWT')
 
-    block_diff_quantized = diff_quantize(frame_data, n)
-    show_ten_closest(frame_data, block_diff_quantized, f, 'Diff Quantization')
+    block_diff_quantized, frame_block_dict = diff_quantize(frame_data, n)
+    show_ten_quantized_closest(frame_data, frame_block_dict, f, n, 'Diff Quantization')
 
     frame_dwt = video_framedwt(frame_data, m)
     show_ten_closest(frame_data, frame_dwt, f, 'Frame-level DWT')


### PR DESCRIPTION
@jakepruitt 
Can you check this out?
We need to update the block with the quantized values for this to work as we build the hist off the block. Lets look into that.

Basically I created a dictionary of dictionaries `frame_block_dict` whose key is the frame number. This dictionary contained in `frame_block_dict` is the dictionary of the block `block_hist_dict` whose key is a tuple `(x,y)` the block coordinate and which contains the histogram for that block. 

Then in the compare function I create the histograms for the blocks of the target frame, and using the dictionary data structure loop through and compare all the histograms of the frames.

This still needs to be adapted for Gabriel's section.
