### PR TITLE
Add scores to matching

### DIFF
--- a/Project 3/frame_dwt.py
+++ b/Project 3/frame_dwt.py
@@ -42,6 +42,38 @@ def frame_dwt(frame):
 
     return dwt
 
+def create_zigzag(width, height):
+    result = list()
+
+    x = 0
+    y = 0
+
+    while x < width-1 or y < height-1:
+        result.append((x,y))
+        if y < height-1:
+            y += 1
+        else:
+            x += 1
+
+        while y > 0 and x < width-1:
+            result.append((x,y))
+            y -= 1
+            x += 1
+
+        result.append((x,y))
+        if x < width-1:
+            x += 1
+        else:
+            y += 1
+
+        while x > 0 and y < height-1:
+            result.append((x,y))
+            x -= 1
+            y += 1
+
+    result.append((x,y))
+    return result
+
 '''
 video_blockdwt
 Applies block-wise dwt to video and writes to .bwt file
@@ -61,15 +93,12 @@ def video_framedwt(frame_data, m):
         print 'Frame number: ' + str(frame_num)
 
         frame_wavelets = frame_dwt(frame)
-        indexes_of_significant_wavelets = np.argsort(np.absolute(frame_wavelets), axis=None)[::-1]
+        zigzag = create_zigzag(len(frame), len(frame[0]))
         for i in range(m):
-            index = indexes_of_significant_wavelets[i]
-            wavelet_x = index//len(frame_wavelets)
-            wavelet_y = index%len(frame_wavelets[0])
             result.append({
                 'frame_num': frame_num,
-                'key': (wavelet_x, wavelet_y),
-                'val': frame_wavelets[wavelet_x, wavelet_y]
+                'key': zigzag[i],
+                'val': frame_wavelets[zigzag[i]]
             })
 
     return result

--- a/Project 3/match_frame.py
+++ b/Project 3/match_frame.py
@@ -100,6 +100,7 @@ def show_ten_quantized_closest(frame_data,frame_block_dict,target_frame_number, 
         top_ten_frames.append((keyA, frame_score))
 
     top_ten_frames.sort(key=lambda tup: tup[1])  # sorts in place
+    top_ten_frames.reverse()
 
     top_ten_frame_indexes = list((x[0] for x in top_ten_frames))    #just need to the frame number, not the diff so we strip that out
     top_ten_frame_values = list((x[1] for x in top_ten_frames))

--- a/Project 3/match_frame.py
+++ b/Project 3/match_frame.py
@@ -46,8 +46,9 @@ def indexes_of_closest_matches(target_features, features_per_frame):
     # Take all of the frames, and for each one apply the score_feature function,
     # which adds up all of the differences in the values in similar keys
     scores = map(score_feature, features_per_frame)
-    closest_matches = [i[0] for i in sorted(enumerate(scores), key=lambda x:x[1])]
-    return closest_matches
+    closest_match_indexes = [i[0] for i in sorted(enumerate(scores), key=lambda x:x[1])]
+    sorted_scores = sorted(scores)
+    return closest_match_indexes, sorted_scores
 
 def show_ten_closest(frame_data, feature_summary, frame_num, description):
     # List of dictionaries - has length of the number of frames, which we will fill
@@ -61,12 +62,15 @@ def show_ten_closest(frame_data, feature_summary, frame_num, description):
     # Grab the frame we're interested in:
     target_features = features_per_frame[frame_num - 1]
     # Get the frame numbers of the most similar frames
-    closest_matches = indexes_of_closest_matches(target_features, features_per_frame)
+    closest_match_indexes, sorted_scores = indexes_of_closest_matches(target_features, features_per_frame)
     for i in range(1,11):
         # For each of those frame numbers, display the image in a window with the number
-        index = closest_matches[i]
+        index = closest_match_indexes[i]
+        score = sorted_scores[i]
         rgb_target = cv2.cvtColor(frame_data[index].astype(np.uint8), cv2.COLOR_GRAY2BGR)
-        cv2.imshow(description + ' ' + str(i), rgb_target)
+        frame_description = description + ' #' + str(i) + ': frame ' + str(index) + '. Score: ' + str(score)
+        print frame_description
+        cv2.imshow(frame_description, rgb_target)
         cv2.waitKey(0)
 
     cv2.destroyAllWindows()
@@ -85,7 +89,7 @@ def show_ten_quantized_closest(frame_data,frame_block_dict,target_frame_number, 
 
     print("Comparing frames...")
     for keyA in frame_block_dict:
-        if keyA == target_frame_number:  #dont compare the frame against itself
+        if keyA == target_frame_number-1:  #dont compare the frame against itself
             continue
         else:
             frame_score = float(0)
@@ -97,15 +101,20 @@ def show_ten_quantized_closest(frame_data,frame_block_dict,target_frame_number, 
 
     top_ten_frames.sort(key=lambda tup: tup[1])  # sorts in place
 
-    top_ten_frames = list((x[0] for x in top_ten_frames))    #just need to the frame number, not the diff so we strip that out
+    top_ten_frame_indexes = list((x[0] for x in top_ten_frames))    #just need to the frame number, not the diff so we strip that out
+    top_ten_frame_values = list((x[1] for x in top_ten_frames))
     for i in range(0,10):
         # For each of those frame numbers, display the image in a window with the number
-        index = top_ten_frames[i]
+        index = top_ten_frame_indexes[i]
+        score = top_ten_frame_values[i]
         rgb_target = cv2.cvtColor(frame_data[index].astype(np.uint8), cv2.COLOR_GRAY2BGR)
-        cv2.imshow(description + ' ' + str(i), rgb_target)
+        frame_description = description + ' #' + str(i + 1) + ': frame ' + str(index) + '. Score: ' + str(score)
+        print frame_description
+        cv2.imshow(frame_description, rgb_target)
         cv2.waitKey(0)
 
     cv2.destroyAllWindows()
+    return
 
 
 if __name__ == '__main__':
@@ -132,7 +141,7 @@ if __name__ == '__main__':
 
     target_frame_data = frame_data[f-1]
     rgb_target = cv2.cvtColor(target_frame_data.astype(np.uint8), cv2.COLOR_GRAY2BGR)
-    cv2.imshow('Original frame', rgb_target)
+    cv2.imshow('Original frame: ' + str(f), rgb_target)
     print 'Displaying Original frame - press any key to continue :)'
     cv2.waitKey(0)
 

--- a/Project 3/match_frame.py
+++ b/Project 3/match_frame.py
@@ -68,7 +68,7 @@ def show_ten_closest(frame_data, feature_summary, frame_num, description):
         index = closest_match_indexes[i]
         score = sorted_scores[i]
         rgb_target = cv2.cvtColor(frame_data[index].astype(np.uint8), cv2.COLOR_GRAY2BGR)
-        frame_description = description + ' #' + str(i) + ': frame ' + str(index) + '. Score: ' + str(score)
+        frame_description = description + ' #' + str(i) + ': frame ' + str(index + 1) + '. Score: ' + str(score)
         print frame_description
         cv2.imshow(frame_description, rgb_target)
         cv2.waitKey(0)
@@ -108,7 +108,7 @@ def show_ten_quantized_closest(frame_data,frame_block_dict,target_frame_number, 
         index = top_ten_frame_indexes[i]
         score = top_ten_frame_values[i]
         rgb_target = cv2.cvtColor(frame_data[index].astype(np.uint8), cv2.COLOR_GRAY2BGR)
-        frame_description = description + ' #' + str(i + 1) + ': frame ' + str(index) + '. Score: ' + str(score)
+        frame_description = description + ' #' + str(i + 1) + ': frame ' + str(index + 1) + '. Score: ' + str(score)
         print frame_description
         cv2.imshow(frame_description, rgb_target)
         cv2.waitKey(0)


### PR DESCRIPTION
Adding the required output of a score for each matched frame. Really useful for debugging, and has revealed a few bugs in the matching code I didn't see before.

@SreeniASU - as part of this PR I added a zigzag function for the `frame_dwt` that can take in a dynamic width and height. Could you take a look at it?

@Perryo looking at the scores produced by the `show_ten_quantized_closest` function, the values are both negative and positive, ranging from -10 to 10 sometimes. As it stands, the code is choosing the most negative scores as best - is this what we want/expect? This may be causing the poor results for quantization diffing.
